### PR TITLE
Update Accessibility Features.txt

### DIFF
--- a/Persistence/Accessibility Features.txt
+++ b/Persistence/Accessibility Features.txt
@@ -6,7 +6,7 @@
 // Read more here: https://attack.mitre.org/wiki/Technique/T1015
 // Tags: #AccessibilityFeatures, #StickyKeys, #ImageFileExecutionOptions, #Debugger, #PriviledgeEscalation, #Persistence
 let minTime = ago(7d);
-let accessibilityProcessNames = dynamic(["utilman.exe","osk.exe","magnify.exe","narrator.exe","displayswitch.exe","atbroker.exe","sethc.exe"]);
+let accessibilityProcessNames = dynamic(["utilman.exe","osk.exe","magnify.exe","narrator.exe","displayswitch.exe","atbroker.exe","sethc.exe", "helppane.exe"]);
 // Query for debuggers attached using a Registry setting to the accessibility processes
 let attachedDebugger =
     RegistryEvents


### PR DESCRIPTION
The %windir%\helppane.exe  is the executable that launches the “Windows Help and Support” (which can be triggered when hitting the F1 key)