### PR TITLE
Remote RuleId from ExploitGuard query

### DIFF
--- a/Protection events/ExploitGuardStats.txt
+++ b/Protection events/ExploitGuardStats.txt
@@ -1,13 +1,11 @@
 // Get stats on ExploitGuard blocks - count events and machines per rule
 MiscEvents
 | where ActionType startswith "ExploitGuard" and ActionType endswith "Blocked"
-| extend RuleId=extractjson("$.RuleId", AdditionalFields, typeof(string))
 // Count total stats - count events and machines per rule
-| summarize EventCount=count(), MachinesCount=dcount(ComputerName) by ActionType, RuleId
+| summarize EventCount=count(), MachinesCount=dcount(ComputerName) by ActionType
 
 // View ExploitGuard audit events - but remove repeating events (e.g. multiple events with same machine, rule, file and process)
 MiscEvents
 | where ActionType startswith "ExploitGuard" and ActionType endswith "Audited"
-| extend RuleId=extractjson("$.RuleId", AdditionalFields, typeof(string))
-| summarize EventTime =max(EventTime) by ComputerName, ActionType,RuleId,FileName, FolderPath, InitiatingProcessCommandLine, InitiatingProcessFileName, InitiatingProcessFolderPath, InitiatingProcessId, SHA1 
+| summarize EventTime =max(EventTime) by ComputerName, ActionType,FileName, FolderPath, InitiatingProcessCommandLine, InitiatingProcessFileName, InitiatingProcessFolderPath, InitiatingProcessId, SHA1 
 


### PR DESCRIPTION
Following the change in ASR ActionType values, they no longer start with ExploitGuard - so this query no longer covers ASR events, and shouldn't use RuleId any longer.