### PR TITLE
Update to include decode64 for python

### DIFF
--- a/Execution/ExecuteBase64DecodedPayload.txt
+++ b/Execution/ExecuteBase64DecodedPayload.txt
@@ -1,11 +1,12 @@
 // Process executed from binary hidden in Base64 encoded file.  Encoding malicious software is a 
 // technique to obfuscate files from detection.
-//   The first ProcessCommandLine component is looking for Python decoding base64
-//   The second ProcesssCommandLine component is looking for the Bash/sh commandline base64 decoding tool
-//   The third one is looking for Ruby decoding base64
+//   The first and second ProcessCommandLine component is looking for Python decoding base64
+//   The third ProcesssCommandLine component is looking for the Bash/sh commandline base64 decoding tool
+//   The fourth one is looking for Ruby decoding base64
 ProcessCreationEvents 
 | where EventTime > ago(14d) 
 | where ProcessCommandLine contains ".decode('base64')"
+        or ProcessCommandLine contains ".b64decode("
         or ProcessCommandLine contains "base64 --decode"
         or ProcessCommandLine contains ".decode64(" 
 | project EventTime , ComputerName , FileName , FolderPath , ProcessCommandLine , InitiatingProcessCommandLine 


### PR DESCRIPTION
Where .decode('base64') did not pick up all the decoding of base64.