### PR TITLE
Exclude Engine Updates and Empty lines

### DIFF
--- a/General queries/WD AV Signature and Platform Version.txt
+++ b/General queries/WD AV Signature and Platform Version.txt
@@ -8,7 +8,7 @@ let startDate = ago(7d);
 FileCreationEvents
 | where InitiatingProcessCommandLine has "MpSigStub.exe"
 //To exclude Engine Updates and non update events 
-| where InitiatingProcessParentFileName != "AM_Engine.exe" and InitiatingProcessParentFileName != "wuauclt.exe"
+| where InitiatingProcessParentFileName !~ "AM_Engine.exe" and InitiatingProcessParentFileName !~ "wuauclt.exe"
 // Comment the below line if you're looking specifically for a computer
 | where EventTime > startDate
 // Uncomment the line below when looking for info regarding a specific computer

--- a/General queries/WD AV Signature and Platform Version.txt
+++ b/General queries/WD AV Signature and Platform Version.txt
@@ -7,6 +7,8 @@
 let startDate = ago(7d);
 FileCreationEvents
 | where InitiatingProcessCommandLine has "MpSigStub.exe"
+//To exclude Engine Updates and non update events 
+| where InitiatingProcessParentFileName != "AM_Engine.exe" and InitiatingProcessParentFileName != "wuauclt.exe"
 // Comment the below line if you're looking specifically for a computer
 | where EventTime > startDate
 // Uncomment the line below when looking for info regarding a specific computer


### PR DESCRIPTION
This excludes engine updates (so really only signature updates are shown) and excludes empty lines.

Engine Updates were in the result set due to entries like this:

MpSigStub.exe /stub 1.1.16500.1 /payload 1.1.16500.1 /MpWUStub /program C:\windows\SoftwareDistribution\Download\Install\AM_Engine.exe /LastPackage

AM_Engine.exe is the file name of engine updates.

Empty results came from this command line "MpSigStub.exe /Store" and the corresponding file name is wuauclt.exe