### PR TITLE
Change from AccountName To AccountSid

### DIFF
--- a/Persistence/scheduled task creation.txt
+++ b/Persistence/scheduled task creation.txt
@@ -1,5 +1,5 @@
 //Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_susp_schtask_creation.yml
 //Questions via Twitter: @janvonkirchheim 
 DeviceProcessEvents 
-| where FolderPath endswith "\\schtasks.exe" and ProcessCommandLine has " /create " and AccountName != "system"
+| where FolderPath endswith "\\schtasks.exe" and ProcessCommandLine has " /create " and AccountSid != "S-1-5-18"
 | where Timestamp > ago(7d)


### PR DESCRIPTION
Since, there is many languages for Windows, there will be different names for SYSTEM user, for instance in Brazil it is called SISTEMA. So, to avoid dependency of string I suggest to change it to SID form AccountSid != "S-1-5-18".