### PR TITLE
improve detection of use of net.exe on CLI

### DIFF
--- a/Discovery/Enumeration of users & groups for lateral movement.txt
+++ b/Discovery/Enumeration of users & groups for lateral movement.txt
@@ -2,7 +2,7 @@
 DeviceProcessEvents 
 | where Timestamp > ago(14d) 
 | where FileName == 'net.exe' and AccountName != "" and ProcessCommandLine !contains '\\'  and ProcessCommandLine !contains '/add' 
-| where (ProcessCommandLine contains ' user ' or ProcessCommandLine contains ' group ') and (ProcessCommandLine endswith ' /do' or ProcessCommandLine endswith ' /domain') 
+| where (ProcessCommandLine contains ' user ' or ProcessCommandLine contains ' group ') and (ProcessCommandLine contains ' /do' or ProcessCommandLine contains ' /domain') 
 | extend Target = extract("(?i)[user|group] (\"*[a-zA-Z0-9-_ ]+\"*)", 1, ProcessCommandLine) | filter Target  != '' 
 | project AccountName, Target, ProcessCommandLine, DeviceName, Timestamp  
 | sort by AccountName, Target


### PR DESCRIPTION
The command line to run net.exe to enumerate users and groups need not have /domain or /do at the end; it can also appear in the middle of the command.  This PR helps improve detection.